### PR TITLE
Added bidds decentralized domains support

### DIFF
--- a/docs/pages/docs/usage.mdx
+++ b/docs/pages/docs/usage.mdx
@@ -148,3 +148,4 @@ try {
 - ArchId - Archway
 - [SpaceId](https://docs.space.id) - Supports .inj and .sei domains
 - [SNS](https://www.sns.id) - Injective .sol domains 
+- [Bidds Decentralized Domains](https://bidds.com) - Coreum .core domains

--- a/src/registry/bdd.spec.ts
+++ b/src/registry/bdd.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { BDD } from './bdd'
+
+describe('BDD', () => {
+  const resolver = new BDD()
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined()
+  })
+
+  it.concurrent(
+    'should resolve thisisatest.core',
+    async () => {
+      const result = await resolver.resolve('thisisatest.core', 'testnet')
+      expect(result).toBe('testcore1y7d6cacnu43fhjlclr67tz6n4wqqe8h8mwdgk9')
+    },
+    10000
+  )
+
+  it.concurrent(
+    'should resolve bdd-registrar-test.core',
+    async () => {
+      const result = await resolver.resolve(
+        'bdd-registrar-test.core',
+        'testnet'
+      )
+      expect(result).toBe('testcore10g5cy007hcmzhh4ta9sne0trasfds59lfdtd2g')
+    },
+    10000
+  )
+
+  it.concurrent(
+    'should return bdd-registrar-test.core',
+    async () => {
+      const result = await resolver.lookup(
+        'testcore10g5cy007hcmzhh4ta9sne0trasfds59lfdtd2g',
+        'testnet'
+      )
+      expect(result).toBe('bdd-registrar-test.core')
+    },
+    10000
+  )
+
+  it.concurrent(
+    'should resolve 5534534g.core',
+    async () => {
+      const result = await resolver.resolve('5534534g.core', 'mainnet')
+      expect(result).toBe('core108a6808s9srwz548x58z7cjt08eur54gjtsv92')
+    },
+    10000
+  )
+
+  it.concurrent(
+    'should resolve bdd-registrar.core',
+    async () => {
+      const result = await resolver.resolve('bdd-registrar.core', 'mainnet')
+      expect(result).toBe('core10g5cy007hcmzhh4ta9sne0trasfds59lless97')
+    },
+    10000
+  )
+
+  it.concurrent(
+    'should return bdd-registrar.core',
+    async () => {
+      const result = await resolver.lookup(
+        'core10g5cy007hcmzhh4ta9sne0trasfds59lless97',
+        'mainnet'
+      )
+      expect(result).toBe('bdd-registrar.core')
+    },
+    10000
+  )
+})

--- a/src/registry/bdd.ts
+++ b/src/registry/bdd.ts
@@ -1,0 +1,90 @@
+import {
+  Addr,
+  AllowedTopLevelDomains,
+  MatchaError,
+  MatchaErrorType,
+  NameService,
+  Network,
+  RpcURLs
+} from './name-service'
+import { decode, encode, fromWords } from 'bech32'
+
+export const serviceID = 'bdd'
+
+const rpcUrls = {
+  mainnet: 'https://full-node.mainnet-1.coreum.dev:26657',
+  testnet: 'https://full-node.testnet-1.coreum.dev:26657'
+}
+
+export class BDD extends NameService {
+  serviceID = serviceID
+  chain = 'coreum'
+  contractAddress = {
+    mainnet: 'core1z22n0xy004sxm5w9fms48exwpl3vwqxd890nt8ve0kwjj048tgqstlqf6f',
+    testnet: 'testcore1uwe9yemth6gr58tm56sx3u37t0c5rhmk963fjt480y4nz3cfxers9fn2kh'
+  }
+
+  async resolve(name: string, network: Network): Promise<string> {
+    const client = await this.getCosmWasmClient(rpcUrls[network])
+    try {
+      const result = await client.queryContractSmart(
+        this.contractAddress[network],
+        {
+          resolve: {
+            name
+          }
+        }
+      )
+      if (!result) {
+        throw new MatchaError('', MatchaErrorType.NOT_FOUND)
+      }
+      return result
+    } catch (err) {
+      throw new MatchaError('', MatchaErrorType.NOT_FOUND)
+    }
+  }
+
+  async lookup(
+    address: string,
+    network: Network,
+    options?: {
+      rpcUrls?: RpcURLs
+    }
+  ): Promise<string> {
+    const client = await this.getCosmWasmClient(
+      options?.rpcUrls?.[serviceID]?.[network] ?? rpcUrls[network]
+    )
+
+    const addr: Addr = {
+      prefix: null,
+      words: null
+    }
+    try {
+      const { prefix, words } = decode(address)
+      addr.prefix = prefix
+      addr.words = words
+    } catch (e) {
+      throw new MatchaError('', MatchaErrorType.INVALID_ADDRESS)
+    }
+
+    const prefix = network === 'mainnet' ? 'core' : 'testcore'
+    const coreAddress = encode(prefix, addr.words)
+    try {
+      const res = await client?.queryContractSmart(
+        this.contractAddress[network],
+        {
+          primary: {
+            address: coreAddress
+          }
+        }
+      )
+      if (!res) {
+        throw new MatchaError('', MatchaErrorType.NOT_FOUND)
+      }
+      return res
+    } catch (e) {
+      console.error(e)
+      throw new MatchaError('', MatchaErrorType.NOT_FOUND)
+    }
+  }
+}

--- a/src/registry/name-service.ts
+++ b/src/registry/name-service.ts
@@ -36,6 +36,7 @@ export type AllowedTopLevelDomains = {
   stargazeNames?: string[]
   spaceIds?: string[]
   sns?: string[]
+  bdd?: string[]
 }
 
 export type rpcUrls = Record<Network, string>
@@ -46,7 +47,8 @@ export type RpcURLs = {
   archIds?: rpcUrls
   stargazeNames?: rpcUrls
   spaceIds?: rpcUrls
-  sns?: rpcUrls
+  sns?: rpcUrls,
+  bdd?: rpcUrls
 }
 
 class CosmWasmClientHandler {

--- a/src/registry/registry.spec.ts
+++ b/src/registry/registry.spec.ts
@@ -26,7 +26,8 @@ describe('registry', () => {
       [services.ibcDomains]: true,
       [services.stargazeNames]: true,
       [services.spaceIds]: true,
-      [services.sns]: true
+      [services.sns]: true,
+      [services.bdd]: true
     })
   })
 
@@ -106,7 +107,8 @@ describe('registry', () => {
         ibcDomains: null,
         stargazeNames: null,
         sns: null,
-        spaceIds: null
+        spaceIds: null,
+        bdd: null,
       })
     },
     10000
@@ -122,7 +124,8 @@ describe('registry', () => {
         ibcDomains: null,
         sns: null,
         stargazeNames: 'cosmos19vf5mfr40awvkefw69nl6p3mmlsnacmm28xyqh',
-        spaceIds: null
+        spaceIds: null,
+        bdd: null,
       })
     },
     10000
@@ -138,7 +141,8 @@ describe('registry', () => {
         ibcDomains: null,
         stargazeNames: null,
         sns: null,
-        spaceIds: 'sei1tmew60aj394kdfff0t54lfaelu3p8j8lz93pmf'
+        spaceIds: 'sei1tmew60aj394kdfff0t54lfaelu3p8j8lz93pmf',
+        bdd: null,
       })
     },
     10000
@@ -195,7 +199,8 @@ describe('registry', () => {
         ibcDomains: 'leapwallet.cosmos',
         stargazeNames: 'messi.cosmos',
         sns: null,
-        spaceIds: null
+        spaceIds: null,
+        bdd: null,
       })
     }
   )
@@ -212,7 +217,8 @@ describe('registry', () => {
         ibcDomains: 'leapwallet.archway',
         stargazeNames: 'messi.archway',
         sns: null,
-        spaceIds: null
+        spaceIds: null,
+        bdd: null,
       })
     }
   )
@@ -229,7 +235,8 @@ describe('registry', () => {
         ibcDomains: null,
         stargazeNames: null,
         sns: null,
-        spaceIds: 'allen.sei'
+        spaceIds: 'allen.sei',
+        bdd: null,
       })
     }
   )
@@ -262,4 +269,56 @@ describe('registry', () => {
     )
     expect(result).toBe('injective1703588265.sol')
   })
+
+  it.concurrent(
+    'should resolve bdd-registrar.core',
+    async () => {
+      const result = await registry.resolve('bdd-registrar.core', services.bdd)
+      expect(result).toBe('core10g5cy007hcmzhh4ta9sne0trasfds59lless97')
+    },
+    10000
+  )
+
+  it.concurrent('should return bdd-registrar.core', async () => {
+    const result = await registry.lookup(
+      'core10g5cy007hcmzhh4ta9sne0trasfds59lless97',
+      services.bdd
+    )
+    expect(result).toBe('bdd-registrar.core')
+  })
+
+  it.concurrent(
+    'should resolveAll for bdd-registrar.core',
+    async () => {
+      const res = await registry.resolveAll('bdd-registrar.core')
+      expect(res).toEqual({
+        archIds: null,
+        icns: null,
+        ibcDomains: null,
+        stargazeNames: null,
+        sns: null,
+        spaceIds: null,
+        bdd: 'core10g5cy007hcmzhh4ta9sne0trasfds59lless97',
+      })
+    },
+    10000
+  )
+
+  it.concurrent(
+    'should lookupAll for core10g5cy007hcmzhh4ta9sne0trasfds59lless97',
+    async () => {
+      const res = await registry.lookupAll(
+        'core10g5cy007hcmzhh4ta9sne0trasfds59lless97'
+      )
+      expect(res).toEqual({
+        archIds: null,
+        icns: null,
+        ibcDomains: null,
+        stargazeNames: null,
+        sns: null,
+        spaceIds: null,
+        bdd: 'bdd-registrar.core',
+      })
+    }
+  )
 })

--- a/src/registry/registry.ts
+++ b/src/registry/registry.ts
@@ -4,6 +4,7 @@ import { StargazeNames, serviceID as _stargazeNamesID } from './stargaze-names'
 import { ArchIdNames, serviceID as _archId } from './arch-id'
 import { SpaceIds, serviceID as _spaceId } from './space-id/space-id'
 import { SNS, serviceID as _sns } from './sns'
+import { BDD, serviceID as _bdd } from './bdd'
 import {
   AllowedTopLevelDomains,
   MatchaError,
@@ -20,7 +21,8 @@ export const services = {
   stargazeNames: _stargazeNamesID,
   archIds: _archId,
   spaceIds: _spaceId,
-  sns: _sns
+  sns: _sns,
+  bdd: _bdd
 }
 
 export const allowedTopLevelDomains = allowedTopLevelDomainData
@@ -36,6 +38,7 @@ export class Registry {
     this.registerService(new ArchIdNames())
     this.registerService(new SpaceIds())
     this.registerService(new SNS())
+    this.registerService(new BDD())
   }
 
   registerService(service: NameService) {


### PR DESCRIPTION
Added support for [Bidds Decentralized Domains (BDD)](https://bidds.com) launched on the 8th of February on Coreum.