### PR TITLE
Fix: Arch ID tests

### DIFF
--- a/src/registry/arch-id.spec.ts
+++ b/src/registry/arch-id.spec.ts
@@ -14,9 +14,9 @@ describe('ArchIds', () => {
   })
 
   it.concurrent(
-    'should resolve leap.arch',
+    'should resolve archfam.arch',
     async () => {
-      const result = await resolver.resolve('leap.arch', 'mainnet')
+      const result = await resolver.resolve('archfam.arch', 'mainnet')
       expect(result).toBe('archway19vf5mfr40awvkefw69nl6p3mmlsnacmmlv6q2q')
     },
     10000
@@ -27,15 +27,6 @@ describe('ArchIds', () => {
     async () => {
       const result = await resolver.resolve('archid.arch', 'mainnet')
       expect(result).toBe('archway1n7d4c52knwqqkw9j975ranknkp4fn3we0unrp6')
-    },
-    10000
-  )
-
-  it.concurrent(
-    'should resolve nft.arch',
-    async () => {
-      const result = await resolver.resolve('nft.arch', 'mainnet')
-      expect(result).toBe('archway1qf0kxkk60qrcj5qa7v7t439249qfkcd4a2rpja')
     },
     10000
   )
@@ -59,7 +50,7 @@ describe('ArchIds', () => {
         'archway19vf5mfr40awvkefw69nl6p3mmlsnacmmlv6q2q',
         'mainnet'
       )
-      expect(result).toEqual('archfam.arch, leap.arch, leapdegens.arch')
+      expect(result).toEqual('archfam.arch, leapdegens.arch')
     },
     10000
   )

--- a/src/registry/nib-id.ts
+++ b/src/registry/nib-id.ts
@@ -51,6 +51,9 @@ export class NibId extends NameService {
   }
 
   async lookup(address: string, network: Network): Promise<string> {
-    throw new MatchaError(`Lookup is unavailable for ${address} on ${network}`, MatchaErrorType.UNAVAILABLE_METHOD)
+    throw new MatchaError(
+      `Lookup is unavailable for ${address} on ${network}`,
+      MatchaErrorType.UNAVAILABLE_METHOD
+    )
   }
 }

--- a/src/registry/registry.spec.ts
+++ b/src/registry/registry.spec.ts
@@ -80,18 +80,18 @@ describe('registry', () => {
   )
 
   it.concurrent(
-    'should resolve leap.arch on archIds',
+    'should resolve leapdegens.arch on archIds',
     async () => {
-      const res = await registry.resolve('leap.arch', services.archIds)
+      const res = await registry.resolve('leapdegens.arch', services.archIds)
       expect(res).toBe('archway19vf5mfr40awvkefw69nl6p3mmlsnacmmlv6q2q')
     },
     10000
   )
 
   it.concurrent(
-    'should resolveAll for leap.arch',
+    'should resolveAll for leapdegens.arch',
     async () => {
-      const res = await registry.resolveAll('leap.arch')
+      const res = await registry.resolveAll('leapdegens.arch')
       expect(res).toEqual({
         archIds: 'archway19vf5mfr40awvkefw69nl6p3mmlsnacmmlv6q2q',
         icns: null,
@@ -190,7 +190,7 @@ describe('registry', () => {
         'archway19vf5mfr40awvkefw69nl6p3mmlsnacmmlv6q2q'
       )
       expect(res).toEqual({
-        archIds: 'archfam.arch, leap.arch, leapdegens.arch',
+        archIds: 'archfam.arch, leapdegens.arch',
         icns: null,
         ibcDomains: 'leapwallet.archway',
         stargazeNames: 'messi.archway',


### PR DESCRIPTION
This fixes breaking Arch ID tests.

Address resolutions for `nft.arch` and `leap.arch` as defined in the tests seem to be out-of-date. I replaced the test resolutions for these with one testing resolution of `archfam.arch` and `leapdegens.arch`, which are known to be active and working.